### PR TITLE
Change authentication method and update test suite to keep up with latest changes in API

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ function makeRequest (url, embed, page) {
     if (embed) query.embed = "true";
     if (page) query.page = page;
     if (!exports.apiKey) throw new Error("No API key.");
-    query.apikey = exports.apiKey;
     return sua.get(url)
+                .set('Authorization', 'W3C-API apikey="' + exports.apiKey + '"')
                 .accept("json")
                 .query(query)
     ;

--- a/test/api.js
+++ b/test/api.js
@@ -136,18 +136,18 @@ describe("Specifications Version", function () {
 
 
 describe("Users", function () {
-    var dino = "ivpki36ou94oo08osswccs80gcwogwk";
+    var ian = "ggdj8tciu9kwwc4o4ww888ggkwok0c8";
     it("can be fetched", function (done) {
-        w3c.user(dino).fetch(itemChecker(done, "given", "Dean"));
+        w3c.user(ian).fetch(itemChecker(done, "given", "Ian"));
     });
     it("have affiliations", function (done) {
-        w3c.user(dino).affiliations().fetch(listChecker(done));
+        w3c.user(ian).affiliations().fetch(listChecker(done));
     });
     it("have groups", function (done) {
-        w3c.user(dino).groups().fetch(listChecker(done, "Alumni"));
+        w3c.user(ian).groups().fetch(listChecker(done, "Community Council"));
     });
     it("have specifications", function (done) {
-        w3c.user(dino).specifications().fetch(listChecker(done, "Scalable Vector Graphics (SVG) Full 1.2 Specification"));
+        w3c.user(ian).specifications().fetch(listChecker(done, "Accessibility Features of CSS"));
     });
 });
 


### PR DESCRIPTION
The test suite was throwing a couple errors after recent changes to the API:

    $ W3CAPIKEY=[MY_KEY] mocha
    
      Domains
        ✓ can be listed (839ms)
        ✓ can be fetched (1137ms)
        ✓ have groups (671ms)
        ✓ have users (648ms)
    
      Groups
        ✓ can be listed (2133ms)
        ✓ can be fetched (631ms)
        ✓ have chairs (2511ms)
        ✓ have services (1226ms)
        ✓ have specifications (1866ms)
        ✓ have teamcontacts (1510ms)
        ✓ have users (2049ms)
        ✓ have charters (723ms)
        ✓ have charters that can be fetched (580ms)
    
      Services
        ✓ can be fetched (606ms)
        ✓ have groups (608ms)
    
      Specifications
        ✓ can be listed (2559ms)
        ✓ can be fetched (605ms)
        ✓ have superseded (582ms)
        ✓ have supersedes (645ms)
        1) have latest
    
      Specifications Version
        ✓ can be listed (503ms)
        ✓ can be fetched (638ms)
        ✓ have deliverers (610ms)
        ✓ have editors (655ms)
        ✓ have next (602ms)
        ✓ have previous (647ms)
    
      Users
        ✓ can be fetched (552ms)
        ✓ have affiliations (717ms)
        2) have groups
        ✓ have specifications (784ms)
    
      Embeds
        ✓ apply to domains (2201ms)
        ✓ apply to groups (5357ms)
        ✓ apply to specifications (4206ms)
    
      31 passing (42s)
      2 failing
    
      1) Specifications have latest:
         Uncaught Error: expected [Error: Unauthorized] to be falsy
          at Assertion.assert (node_modules/expect.js/index.js:96:13)
          at Assertion.ok (node_modules/expect.js/index.js:115:10)
          at Function.ok (node_modules/expect.js/index.js:499:17)
          at test/api.js:32:31
          at index.js:53:25
          at Request.callback (node_modules/superagent/lib/node/index.js:797:3)
          at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:990:12)
          at endReadableNT (_stream_readable.js:905:12)
    
      2) Users have groups:
         Uncaught TypeError: Cannot read property 'title' of undefined
          at test/api.js:16:62
          at Array.some (native)
          at test/api.js:16:32
          at index.js:81:17
          at node_modules/async/lib/async.js:52:16
          at node_modules/async/lib/async.js:361:13
          at node_modules/async/lib/async.js:52:16
          at async.forEachOf.async.eachOf (node_modules/async/lib/async.js:236:30)
          at _asyncMap (node_modules/async/lib/async.js:355:9)
          at Object.map (node_modules/async/lib/async.js:337:20)
          at index.js:68:15
          at Request.callback (node_modules/superagent/lib/node/index.js:785:12)
          at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:990:12)
          at endReadableNT (_stream_readable.js:905:12)

This PR fixes both.

The first error was caused [by a redirection](https://github.com/w3c/w3c-api/issues/16#issuecomment-159277270); the other test failed because the person used for the test isn't associated to any public groups, and now [only those are being shown](https://github.com/w3c/w3c-api/issues/45).