### PR TITLE
Update tests with new expected results

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -167,7 +167,7 @@ describe('Affiliations', function () {
         w3c.affiliation(STAFF).participants().fetch(listChecker(done, 'Kazuyuki Ashimura'));
     });
     it('have participations', function (done) {
-        w3c.affiliation(STAFF).participations().fetch(listChecker(done, 'Evaluation and Repair Tools Working Group'));
+        w3c.affiliation(STAFF).participations().fetch(listChecker(done, 'Web and TV Interest Group'));
     });
 });
 


### PR DESCRIPTION
In particular, staff participations have changed.

This is why #28 is failing.