### PR TITLE
Support for non-participant licensing commitments endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -253,3 +253,24 @@ function CallForTranslationCtx (ctx) {
 // FIXME: idStep assumes subSteps has been run before
 subSteps(CallForTranslationCtx, []);
 exports.callfortranslation = idStep(CallForTranslationCtx, 'callsfortranslation');
+
+//------------------------------------- 10. Non-participant Licensing commitments
+
+exports.nplcs = rootList("nplcs");
+
+function NplcCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+
+subSteps(NplcCtx, ['']);
+function contributionStep(obj, name) {
+    return function (contribution) {
+        var ctx = new obj();
+        ctx.steps.push(name);
+        ctx.steps.push(contribution.repoId);
+        ctx.steps.push(contribution.pr);
+        return ctx;
+    };
+}
+
+exports.nplc = contributionStep(NplcCtx, 'nplcs');

--- a/lib/w3capi.js
+++ b/lib/w3capi.js
@@ -255,6 +255,27 @@ function CallForTranslationCtx (ctx) {
 subSteps(CallForTranslationCtx, []);
 exports.callfortranslation = idStep(CallForTranslationCtx, 'callsfortranslation');
 
+//------------------------------------- 10. Non-participant licensing commitments
+
+exports.nplcs = rootList("nplcs");
+
+function NplcCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+
+subSteps(NplcCtx, []);
+function contributionStep(obj, name) {
+    return function (contribution) {
+        var ctx = new obj();
+        ctx.steps.push(name);
+        ctx.steps.push(contribution.repoId);
+        ctx.steps.push(contribution.pr);
+        return ctx;
+    };
+}
+
+exports.nplc = contributionStep(NplcCtx, 'nplcs');
+
 },{"async":2,"superagent":6,"util":14}],2:[function(require,module,exports){
 (function (process,global){
 (function (global, factory) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-w3capi",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "description": "A JavaScript client for the W3C API",
   "main": "lib/index.js",

--- a/test/api.js
+++ b/test/api.js
@@ -205,6 +205,16 @@ describe('Call for translations', function () {
     });
 });
 
+// Uncomment and adapt the test when we have a contribution in the database
+//describe('Non-participant licensing commitments', function () {
+//    it("can be listed", function (done) {
+//        w3c.nplcs().fetch(listChecker(done, 15309233, 'repoId'));
+//    });
+//    it('can be fetched', function (done) {
+//        w3c.nplc({repoId: 15309233, pr: 840}).fetch(itemChecker(done, 'repository', 15309233));
+//    });
+//});
+
 describe("Embeds", function () {
     it('apply to functions', function (done) {
         w3c.functions().fetch({ embed: true }, embedChecker(done, 'name', 'Management'));


### PR DESCRIPTION
This PR adds support for the non-participant licensing commitments.
The API will soon expose 2 endpoints to expose them:
* /nplcs
* /nplcs/{repositoryId}/{prId}

This is to be merged only after the new version of the API is released.

Note, the tests are commented out because we have no contributions at the moment but as soon as we have one, we can enable the tests and adapt the parameters accordingly.