### PR TITLE
support for user.teamcontactofgroups

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,13 @@ function UserCtx (ctx) {
 
 subSteps(UserCtx, ["affiliations", "groups", "participations", "specifications"]);
 
+UserCtx.prototype.teamcontactofgroups = function() {
+    this.steps.push('team-contact-of-groups');
+    this.type = "list";
+    this.linkKey = "groups";
+    return this;
+}
+
 // generates a step that takes either an account object or an ID
 function accountOrIdStep(obj, name) {
     return function (accountOrId) {

--- a/test/api.js
+++ b/test/api.js
@@ -157,6 +157,9 @@ describe("Users", function () {
     it("have specifications", function (done) {
         w3c.user(ian).specifications().fetch(listChecker(done, "Accessibility Features of CSS"));
     });
+    it("is team contact of", function (done) {
+        w3c.user(ian).teamcontactofgroups().fetch(listChecker(done, "Web Payments Working Group"));
+    });
 });
 
 describe('Affiliations', function () {


### PR DESCRIPTION
That PR adds support for the [teamcontactofgroups endpoint](https://api.w3.org/doc#operations-Users-get_users__hash__team_contact_of_groups)