### PR TITLE
The embedded property may be missing if the underlying collection is empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,12 +74,12 @@ Ctx.prototype.fetch = async function (options, cb) {
                 req.end(function (err, res) {
                     if (err) return cb(err);
                     if (!res.ok) return cb(res.text);
-                    cb(null, arrayify(res.body[embedKey][key]));
+                    cb(null, arrayify(res.body?.[embedKey]?.[key] ?? []));
                 });
             }
         ,   function (err, allRes) {
                 if (err) return cb(err);
-                var allData = arrayify(body[embedKey][key]);
+                var allData = arrayify(body?.[embedKey]?.[key] ?? []);
                 allRes.forEach(function (res) { allData = allData.concat(res); });
                 cb(null, allData);
             }


### PR DESCRIPTION
The new version of the W3C API is causing a breaking change when collections are empty