### PR TITLE
Replace var with const/let

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var sua = require("superagent")
+const sua = require("superagent")
 ,   util = require("util")
 ,   async = require("async")
 ;
@@ -11,7 +11,7 @@ exports.authMode = 'header';
 
 // slurping helper
 function makeRequest (url, embed, page) {
-    var query = {}
+    const query = {}
     ,   result = sua.get(url);
     if (embed) query.embed = "true";
     if (page) query.page = page;
@@ -42,7 +42,7 @@ Ctx.prototype.fetch = async function (options, cb) {
         cb = (err, result) => { if (err) return reject(err); return resolve(result) ; } ;
     }
 
-    var url = exports.baseURL + this.steps.join("/")
+    const url = exports.baseURL + this.steps.join("/")
     ,   embed = options && options.embed
     ,   request = makeRequest(url, embed)
     ,   type = this.type || "item"
@@ -55,15 +55,14 @@ Ctx.prototype.fetch = async function (options, cb) {
     request.end(function (err, res) {
         if (err) return cb(err);
         if (!res.ok) return cb(res.text);
-        var body = res.body;
+        const body = res.body;
         // if what we were fetching was a single item, we're good
         if (type === "item") return cb(null, res.body);
         // if it's a list but it has only one page, we're good
         if (body.pages == 1) return cb(null, arrayify(body[embedKey][key]));
         // otherwise we're dealing with a list that may be paged
-        var reqs = []
-        ,   page = 1
-        ;
+        const reqs = [];
+        let page = 1;
         while (page < body.pages) {
             page++;
             reqs.push(makeRequest(url, embed, page));
@@ -79,7 +78,7 @@ Ctx.prototype.fetch = async function (options, cb) {
             }
         ,   function (err, allRes) {
                 if (err) return cb(err);
-                var allData = arrayify(body?.[embedKey]?.[key] ?? []);
+                let allData = arrayify(body?.[embedKey]?.[key] ?? []);
                 allRes.forEach(function (res) { allData = allData.concat(res); });
                 cb(null, allData);
             }
@@ -94,7 +93,7 @@ Ctx.prototype.fetch = async function (options, cb) {
 // generates a function for the root list
 function rootList (type, linkKey) {
     return function (name) {
-        var ctx = new Ctx();
+        const ctx = new Ctx();
         ctx.type = "list";
         ctx.linkKey = linkKey ? linkKey : type;
         ctx.steps = [type];
@@ -107,13 +106,13 @@ function rootList (type, linkKey) {
 function subSteps (obj, items) {
     util.inherits(obj, Ctx);
 
-    var key = "teamcontacts versions successors predecessors".split(" ")
+    const key = "teamcontacts versions successors predecessors".split(" ")
     ,   propKey = "team-contacts version-history successor-version predecessor-version".split(" ");
     items.forEach(function (it) {
         obj.prototype[it] = function () {
             this.steps.push(it);
             this.type = "list";
-            var i = key.indexOf(it);
+            const i = key.indexOf(it);
             this.linkKey = (i >= 0) ? propKey[i] : it;
             return this;
         };
@@ -123,7 +122,7 @@ function subSteps (obj, items) {
 // generates a step that takes an ID
 function idStep (obj, name, inherit) {
     return function (id) {
-        var ctx = obj ? new obj(inherit ? this : undefined) : this;
+        const ctx = obj ? new obj(inherit ? this : undefined) : this;
         ctx.steps.push(name);
         ctx.steps.push(id);
         return ctx;
@@ -157,7 +156,7 @@ function shortnameOrIdStep(obj, name) {
             // W3C group id
             return idStep(obj, name)(shortnameOrId);
         } else {
-            var ctx = new obj();
+            const ctx = new obj();
             ctx.steps.push(name);
             ctx.steps.push(shortnameOrId.type);
             ctx.steps.push(shortnameOrId.shortname);
@@ -227,7 +226,7 @@ function accountOrIdStep(obj, name) {
             return idStep(obj, name)(accountOrId);
         } else {
             // accountOrId expected to be {type: 'github', id: 123456}
-            var ctx = new obj();
+            const ctx = new obj();
             ctx.steps.push(name);
             ctx.steps.push("connected");
             ctx.steps.push(accountOrId.type);
@@ -294,7 +293,7 @@ function NplcCtx (ctx) {
 subSteps(NplcCtx, ['']);
 function contributionStep(obj, name) {
     return function (contribution) {
-        var ctx = new obj();
+        const ctx = new obj();
         ctx.steps.push(name);
         ctx.steps.push(contribution.repoId);
         ctx.steps.push(contribution.pr);

--- a/test/api.js
+++ b/test/api.js
@@ -1,4 +1,4 @@
-var expect = require("expect.js")
+const expect = require("expect.js")
 ,   w3c = require("..")
 ;
 
@@ -161,7 +161,7 @@ describe("Specifications Version", function () {
 
 
 describe("Users", function () {
-    var ian = "ggdj8tciu9kwwc4o4ww888ggkwok0c8";
+    const ian = "ggdj8tciu9kwwc4o4ww888ggkwok0c8";
     it("can be fetched", function (done) {
         w3c.user(ian).fetch(itemChecker(done, "given", "Ian"));
     });


### PR DESCRIPTION
All `require` and variables that will not be reassigned (such as url, body, ctx, key, etc.) changed to `const`. Two variables that will be reassigned (`page` and `allData`) changed to `let`.